### PR TITLE
Replace nodeValue with textContent

### DIFF
--- a/test/data/cdata.kml
+++ b/test/data/cdata.kml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <description>
+      <![CDATA[
+
+             Here is some text
+      ]]></description>
+    <Point>
+      <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+    </Point>
+  </Placemark>
+</kml>

--- a/test/data/cdata.kml.geojson
+++ b/test/data/cdata.kml.geojson
@@ -1,0 +1,19 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -122.0822035425683,
+                    37.42228990140251,
+                    0
+                ]
+            },
+            "properties": {
+                "description": "\n      \n\n             Here is some text\n      "
+            }
+        }
+    ]
+}

--- a/test/data/gxmultitrack.kml.geojson
+++ b/test/data/gxmultitrack.kml.geojson
@@ -12,7 +12,7 @@
                 ]
             },
             "properties": {
-                "name": "\n",
+                "name": "\n12/04/2014 11:24 AM (départ)\n   ",
                 "styleUrl": "#start",
                 "styleHash": "-13d91d2a",
                 "description": "\n\n   "
@@ -166,11 +166,11 @@
                 ]
             },
             "properties": {
-                "name": "\n",
+                "name": "\n12/04/2014 11:24 AM\n   ",
                 "styleUrl": "#track",
                 "styleHash": "-4182fe62",
                 "description": "\n\n   ",
-                "type": "\n",
+                "type": "\ncourse à pied\n     ",
                 "coordTimes": [
                     [
                         "2014-04-12T14:26:16.702Z",
@@ -217,10 +217,10 @@
                 ]
             },
             "properties": {
-                "name": "\n",
+                "name": "\n12/04/2014 11:24 AM (fin)\n   ",
                 "styleUrl": "#end",
                 "styleHash": "10d07b61",
-                "description": "\n"
+                "description": "\nCréé par Google Mes parcours sur Android\n\nNom : 12/04/2014 11:24 AM\nType d'activité : course à pied\nDescription : -\nDistance totale : 10,43 km (6,5 mi)\nDurée totale : 1:13:38\nDurée du déplacement : 1:08:20\nVitesse moyenne : 8,49 km/h (5,3 mi/h)\nVitesse moyenne de déplacement : 9,16 km/h (5,7 mi/h)\nVitesse max. : 12,84 km/h (8,0 mi/h)\nVitesse moyenne : 7:04 min/km (11:22 min/mi)\nAllure moyenne : 6:33 min/km (10:33 min/mi)\nVitesse maximale : 4:40 min/km (7:31 min/mi)\nÉlévation max. : 1020 m (3347 pi)\nÉlévation min. : 678 m (2223 pi)\nDénivelé : 1095 m (3593 pi)\nInclinaison max. : 21 %\nInclinaison min. : -24 %\nDate d'enregistrement : 12/04/2014 11:24 AM\n\n   "
             }
         }
     ]

--- a/togeojson.js
+++ b/togeojson.js
@@ -32,7 +32,7 @@ var toGeoJSON = (function() {
     // get the content of a text node, if any
     function nodeVal(x) {
         if (x) { norm(x); }
-        return (x && x.firstChild && x.firstChild.nodeValue) || '';
+        return (x && x.textContent) || '';
     }
     // get one coordinate from a coordinate array, if any
     function coord1(v) { return numarray(v.replace(removeSpace, '').split(',')); }


### PR DESCRIPTION
A fix for #56. This uses [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) to get the entire content of the node, instead of just the value of the first child. 