### PR TITLE
Adding functionality to pick up on "-normal" and "-highlight" styles

### DIFF
--- a/togeojson.js
+++ b/togeojson.js
@@ -187,9 +187,13 @@ var toGeoJSON = (function() {
 
                 if (!geomsAndTimes.geoms.length) return [];
                 if (name) properties.name = name;
-                if (styleUrl && styleIndex[styleUrl]) {
+                if (styleUrl && (styleIndex[styleUrl] || styleIndex[styleUrl + '-normal'])) {
                     properties.styleUrl = styleUrl;
-                    properties.styleHash = styleIndex[styleUrl];
+                    properties.styleNormalUrl = styleUrl + '-normal';
+                    properties.styleNormalHash = styleIndex[properties.styleNormalUrl];
+                    properties.styleHash = styleIndex[styleUrl] || properties.styleNormalHash;
+                    properties.styleHighlightUrl = styleUrl + '-highlight';
+                    properties.styleHighlightHash = styleIndex[properties.styleHighlightUrl];
                 }
                 if (description) properties.description = description;
                 if (timeSpan) {


### PR DESCRIPTION
This fixes a bug where styles are no longer getting picked up on by the module because of a change in how style data is stored (at least in kmz data from google maps engine)

To directly pick up on the style tags for a given id, "-normal" must be added and a "-highlight" tag also exists. for kml/kmz files that use this format (google maps engine does at least) just using styleUrl is thus no longer sufficient to find the style data, so "id + '-normal'" and "id + '-highlight'" have to be checked for the data to be found by the module.