### PR TITLE
Added support for StyleMap styles

### DIFF
--- a/togeojson.js
+++ b/togeojson.js
@@ -98,10 +98,14 @@ var toGeoJSON = (function() {
                 geotypes = ['Polygon', 'LineString', 'Point', 'Track', 'gx:Track'],
                 // all root placemarks in the file
                 placemarks = get(doc, 'Placemark'),
-                styles = get(doc, 'Style');
+                styles = get(doc, 'Style'),
+                styleMaps = get(doc, 'StyleMap');
 
             for (var k = 0; k < styles.length; k++) {
                 styleIndex['#' + attr(styles[k], 'id')] = okhash(xml2str(styles[k])).toString(16);
+            }
+            for (var k = 0; k < styleMaps.length; k++) {
+                styleIndex['#' + attr(styleMaps[k], 'id')] = okhash(xml2str(styleMaps[k])).toString(16);
             }
             for (var j = 0; j < placemarks.length; j++) {
                 gj.features = gj.features.concat(getPlacemark(placemarks[j]));


### PR DESCRIPTION
While using togeojson to load [this KML file](http://www.hoogspanningsnet.com/wp-content/uploads/Standaardnetkaart-van-de-Benelux.kmz) (unzipped locally), I noticed that the StyleMap styles were ignored. In this PR I treat them similarly as regular styles, and added them to the styleIndex, so I can later extract them and recreate the style.

![image](https://cloud.githubusercontent.com/assets/3140667/8759257/7588fdc8-2cf0-11e5-972b-249d3fff7a24.png)


