### PR TITLE
KML Color needs hash symbol

### DIFF
--- a/togeojson.js
+++ b/togeojson.js
@@ -113,7 +113,7 @@ var toGeoJSON = (function() {
                 if (v.length === 6 || v.length === 3) { color = v; }
                 if (v.length === 8) {
                     opacity = parseInt(v.substr(0, 2), 16) / 255;
-                    color = v.substr(2);
+                    color = '#'+v.substr(2);
                 }
                 return [color, isNaN(opacity) ? undefined : opacity];
             }


### PR DESCRIPTION
The KML color that is being parsed doesn't come out with a hash symbol and is therefore not parsable by simplestyle methods...