### PR TITLE
Adding style attributes to placemark properties

### DIFF
--- a/test/data/gxmultitrack.kml.geojson
+++ b/test/data/gxmultitrack.kml.geojson
@@ -170,6 +170,9 @@
                 "styleUrl": "#track",
                 "styleHash": "-4182fe62",
                 "description": "\n\n   ",
+                "stroke": "#0000ff",
+                "stroke-opacity": 0.4980392156862745,
+                "stroke-width": 4,
                 "type": "\ncourse à pied\n     ",
                 "coordTimes": [
                     [

--- a/test/data/inline_style.kml.geojson
+++ b/test/data/inline_style.kml.geojson
@@ -54,8 +54,6 @@
             },
             "properties": {
                 "name": "With all inline styles",
-                "styleUrl": "#",
-                "styleHash": "-211050d",
                 "stroke": "#0000ff",
                 "stroke-opacity": 0,
                 "stroke-width": 3,
@@ -116,8 +114,6 @@
             },
             "properties": {
                 "name": "With some inline styles",
-                "styleUrl": "#",
-                "styleHash": "-211050d",
                 "stroke": "#0000ff",
                 "stroke-opacity": 1,
                 "fill-opacity": 1
@@ -159,9 +155,7 @@
                 ]
             },
             "properties": {
-                "name": "Without inline style",
-                "styleUrl": "#",
-                "styleHash": "-211050d"
+                "name": "Without inline style"
             }
         }
     ]

--- a/test/data/literal_color.kml.geojson
+++ b/test/data/literal_color.kml.geojson
@@ -54,8 +54,6 @@
             },
             "properties": {
                 "name": "With all inline styles",
-                "styleUrl": "#",
-                "styleHash": "-5813b456",
                 "stroke": "ff0",
                 "stroke-width": 3,
                 "fill": "ff0011",

--- a/test/data/multitrack.kml.geojson
+++ b/test/data/multitrack.kml.geojson
@@ -108,6 +108,9 @@
                 "name": "8/8/2013 17:20",
                 "styleUrl": "#track",
                 "styleHash": "-1fdecab8",
+                "stroke": "#0000ff",
+                "stroke-opacity": 0.4980392156862745,
+                "stroke-width": 4,
                 "type": "walking",
                 "coordTimes": [
                     "2013-08-08T15:24:47.000Z",

--- a/test/data/non_gx_multitrack.kml.geojson
+++ b/test/data/non_gx_multitrack.kml.geojson
@@ -108,6 +108,9 @@
                 "name": "8/8/2013 17:20",
                 "styleUrl": "#track",
                 "styleHash": "-1fdecab8",
+                "stroke": "#0000ff",
+                "stroke-opacity": 0.4980392156862745,
+                "stroke-width": 4,
                 "type": "walking",
                 "coordTimes": [
                     "2013-08-08T15:24:47.000Z",

--- a/test/data/noname.kml.geojson
+++ b/test/data/noname.kml.geojson
@@ -53,8 +53,6 @@
                 ]
             },
             "properties": {
-                "styleUrl": "#",
-                "styleHash": "-5813b456",
                 "stroke": "ff0",
                 "stroke-width": 3,
                 "fill": "ff0011",

--- a/test/data/style_url.kml.geojson
+++ b/test/data/style_url.kml.geojson
@@ -108,7 +108,10 @@
             "properties": {
                 "name": "Building 41",
                 "styleUrl": "#transBluePoly",
-                "styleHash": "-28fa1d02"
+                "styleHash": "-28fa1d02",
+                "stroke-width": 1.5,
+                "fill": "#ff0000",
+                "fill-opacity": 0.49019607843137253
             }
         }
     ]

--- a/test/data/timespan.kml.geojson
+++ b/test/data/timespan.kml.geojson
@@ -27,6 +27,7 @@
             },
             "properties": {
                 "name": "1",
+                "styleUrl": "#FEATURES",
                 "timespan": {
                     "begin": "0725",
                     "end": "0733"

--- a/togeojson.js
+++ b/togeojson.js
@@ -115,7 +115,7 @@ var toGeoJSON = (function() {
                 var pairs = get(styleMaps[l], 'Pair');
                 var pairsMap = {};
                 for (var m = 0; m < pairs.length; m++) {
-                  pairsMap[nodeVal(get1(pairs[m], 'key'))] = nodeVal(get1(pairs[m], 'styleUrl'));
+                    pairsMap[nodeVal(get1(pairs[m], 'key'))] = nodeVal(get1(pairs[m], 'styleUrl'));
                 }
                 styleMapIndex['#' + attr(styleMaps[l], 'id')] = pairsMap;
 
@@ -207,22 +207,22 @@ var toGeoJSON = (function() {
                 if (!geomsAndTimes.geoms.length) return [];
                 if (name) properties.name = name;
                 if (styleUrl) {
-                  if (styleUrl[0] !== '#') {
-                      styleUrl = '#' + styleUrl;
-                  }
+                    if (styleUrl[0] !== '#') {
+                        styleUrl = '#' + styleUrl;
+                    }
 
-                  properties.styleUrl = styleUrl;
-                  if (styleIndex[styleUrl]) {
-                    properties.styleHash = styleIndex[styleUrl];
-                  }
-                  if (styleMapIndex[styleUrl]) {
-                    properties.styleMapHash = styleMapIndex[styleUrl];
-                    properties.styleHash = styleIndex[styleMapIndex[styleUrl].normal];
-                  }
-                  // Try to populate the lineStyle or polyStyle since we got the style hash
-                  var style = styleByHash[properties.styleHash];
-                  if (!lineStyle) lineStyle = get1(style, 'LineStyle');
-                  if (!polyStyle) polyStyle = get1(style, 'PolyStyle');
+                    properties.styleUrl = styleUrl;
+                    if (styleIndex[styleUrl]) {
+                        properties.styleHash = styleIndex[styleUrl];
+                    }
+                    if (styleMapIndex[styleUrl]) {
+                        properties.styleMapHash = styleMapIndex[styleUrl];
+                        properties.styleHash = styleIndex[styleMapIndex[styleUrl].normal];
+                    }
+                    // Try to populate the lineStyle or polyStyle since we got the style hash
+                    var style = styleByHash[properties.styleHash];
+                    if (!lineStyle) lineStyle = get1(style, 'LineStyle');
+                    if (!polyStyle) polyStyle = get1(style, 'PolyStyle');
                 }
                 if (description) properties.description = description;
                 if (timeSpan) {

--- a/togeojson.js
+++ b/togeojson.js
@@ -221,8 +221,10 @@ var toGeoJSON = (function() {
                     }
                     // Try to populate the lineStyle or polyStyle since we got the style hash
                     var style = styleByHash[properties.styleHash];
-                    if (!lineStyle) lineStyle = get1(style, 'LineStyle');
-                    if (!polyStyle) polyStyle = get1(style, 'PolyStyle');
+                    if (style) {
+                        if (!lineStyle) lineStyle = get1(style, 'LineStyle');
+                        if (!polyStyle) polyStyle = get1(style, 'PolyStyle');
+                    }
                 }
                 if (description) properties.description = description;
                 if (timeSpan) {


### PR DESCRIPTION
I was trying to find a way of easily accessing style attributes of a given `LineString` -- like `LineStyle` for example -- and noticed that they would be placed inside the `properties` hash if the attributes were inside a Placemark tag, but not if they were only in the `style`, of `styleMap`.

Most of the time it would be handy to be able to access this properties, so I forked your repo and implemented it =].

It looks like this:
![screen shot 2016-02-04 at 3 29 19 pm](https://cloud.githubusercontent.com/assets/88702/12833234/297de17a-cb54-11e5-8768-389146483d97.png)

Hope you feel like it's a valid contribution, maybe there are some aspects of the implementation we could discuss, like the extra dictionary I had to create for performance reasons, `styleByHash`.

Best!