### PR TITLE
Add Timestamp Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Supported:
 * Styles with hashing
 * Tracks & MultiTracks with `gx:coords`, including altitude
 * [TimeSpan](https://developers.google.com/kml/documentation/kmlreference#timespan)
+* [TimeStamp](https://developers.google.com/kml/documentation/kmlreference#timestamp)
 
 Not supported yet:
 

--- a/togeojson.js
+++ b/togeojson.js
@@ -237,7 +237,7 @@ var toGeoJSON = (function() {
                 }
                 if (timeStamp) {
                     var when = nodeVal(get1(timeStamp, 'when'));
-                    properties.timespan = { when: when };
+                    properties.timestamp = { when: when };
                 }
                 if (lineStyle) {
                     var linestyles = kmlColor(nodeVal(get1(lineStyle, 'color'))),

--- a/togeojson.js
+++ b/togeojson.js
@@ -236,8 +236,7 @@ var toGeoJSON = (function() {
                     properties.timespan = { begin: begin, end: end };
                 }
                 if (timeStamp) {
-                    var when = nodeVal(get1(timeStamp, 'when'));
-                    properties.timestamp = { when: when };
+                    properties.timestamp = nodeVal(get1(timeStamp, 'when'));
                 }
                 if (lineStyle) {
                     var linestyles = kmlColor(nodeVal(get1(lineStyle, 'color'))),

--- a/togeojson.js
+++ b/togeojson.js
@@ -201,6 +201,7 @@ var toGeoJSON = (function() {
                     styleUrl = nodeVal(get1(root, 'styleUrl')),
                     description = nodeVal(get1(root, 'description')),
                     timeSpan = get1(root, 'TimeSpan'),
+                    timeStamp = get1(root, 'TimeStamp'),
                     extendedData = get1(root, 'ExtendedData'),
                     lineStyle = get1(root, 'LineStyle'),
                     polyStyle = get1(root, 'PolyStyle'),
@@ -233,6 +234,10 @@ var toGeoJSON = (function() {
                     var begin = nodeVal(get1(timeSpan, 'begin'));
                     var end = nodeVal(get1(timeSpan, 'end'));
                     properties.timespan = { begin: begin, end: end };
+                }
+                if (timeStamp) {
+                    var when = nodeVal(get1(timeStamp, 'when'));
+                    properties.timespan = { when: when };
                 }
                 if (lineStyle) {
                     var linestyles = kmlColor(nodeVal(get1(lineStyle, 'color'))),


### PR DESCRIPTION
I'm interested in adding the [TimeStamp](https://developers.google.com/kml/documentation/kmlreference#timestamp) property for features like `<Placemark>`.

Here's a pull request to do that and it breaks several tests:

```spec
  Failed Tests: There were 3 failures

    KML

      ✖ test/data/gxmultitrack.kml
      ✖ test/data/multitrack.kml
      ✖ test/data/non_gx_multitrack.kml
```

I see that by running the tests as `UPDATE=true npm test` the tests no longer break, but I'm just learning my way around KML and GeoJSON and this project, and I'm not sure if that's advisable or not.