### PR TITLE
Improved GPX property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ just AJAX.
 ### GPX Feature Support
 
 * [x] Line Paths
-* [x] 'name', 'cmt', 'desc', 'author', 'copyright', 'link', 'time', 'keywords' tags
+* [ ] Properties
+  * [x] 'name', 'cmt', 'desc', 'link', 'time', 'keywords' tags
+  * [ ] 'author', 'copyright' tags
 
 ## FAQ
 

--- a/test/data/gdal.gpx
+++ b/test/data/gdal.gpx
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!-- GPX sample. X/MIT licence -->
+<gpx creator="E. Rouault" version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<wpt lat="0" lon="1">
+  <ele>2</ele> 
+  <name>waypoint name</name>
+  <cmt>waypoint comment</cmt>
+  <desc>waypoint description</desc>
+  <src>waypoint source</src>
+  <link href="href"><text>text</text><type>type</type></link>
+  <link href="href2"><text>text2</text><type>type2</type></link>
+  <link href="href3"><text>text3</text><type>type3</type></link>
+  <time>2007-11-25T17:58:00+01:00</time>
+  <extensions></extensions>
+</wpt>
+<wpt lat="3" lon="4"/>
+<rte>
+  <name>route name</name>
+  <rtept lat="5" lon="6">
+      <ele>7</ele> 
+      <name>route point name</name>
+      <time>2007-11-25T17:58:00Z</time>
+  </rtept>
+  <rtept lat="8" lon="9">
+      <ele>10</ele> 
+  </rtept>
+  <rtept lat="11" lon="12">
+      <ele>13</ele> 
+  </rtept>
+</rte>
+<rte>
+    <name>empty route</name>
+</rte>
+<trk>
+    <name>track name</name>
+    <trkseg>
+        <trkpt lat="14" lon="15">
+            <ele>16</ele> 
+            <name>track point name</name>
+        </trkpt>
+        <trkpt lat="17" lon="18">
+            <ele>19</ele> 
+        </trkpt>
+    </trkseg>
+    <trkseg>
+        <trkpt lat="20" lon="21">
+            <ele>22</ele> 
+        </trkpt>
+        <trkpt lat="23" lon="24">
+            <ele>25</ele> 
+        </trkpt>
+    </trkseg>
+</trk>
+<trk>
+    <name>empty track</name>
+</trk>
+<trk>
+    <name>empty track 2</name>
+    <trkseg>
+    </trkseg>
+</trk>
+</gpx>

--- a/test/data/gdal.gpx.geojson
+++ b/test/data/gdal.gpx.geojson
@@ -1,0 +1,115 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "track name"
+            },
+            "geometry": {
+                "type": "MultiLineString",
+                "coordinates": [
+                    [
+                        [
+                            15,
+                            14,
+                            16
+                        ],
+                        [
+                            18,
+                            17,
+                            19
+                        ]
+                    ],
+                    [
+                        [
+                            21,
+                            20,
+                            22
+                        ],
+                        [
+                            24,
+                            23,
+                            25
+                        ]
+                    ]
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "route name",
+                "time": "2007-11-25T17:58:00Z"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [
+                        6,
+                        5,
+                        7
+                    ],
+                    [
+                        9,
+                        8,
+                        10
+                    ],
+                    [
+                        12,
+                        11,
+                        13
+                    ]
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "waypoint name",
+                "cmt": "waypoint comment",
+                "desc": "waypoint description",
+                "time": "2007-11-25T17:58:00+01:00",
+                "links": [
+                    {
+                        "text": "text",
+                        "type": "type",
+                        "href": "href"
+                    },
+                    {
+                        "text": "text2",
+                        "type": "type2",
+                        "href": "href2"
+                    },
+                    {
+                        "text": "text3",
+                        "type": "type3",
+                        "href": "href3"
+                    }
+                ],
+                "sym": ""
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    1,
+                    0,
+                    2
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "sym": ""
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    4,
+                    3
+                ]
+            }
+        }
+    ]
+}

--- a/togeojson.js
+++ b/togeojson.js
@@ -24,15 +24,19 @@ var toGeoJSON = (function() {
         for (var j = 0, o = []; j < x.length; j++) { o[j] = parseFloat(x[j]); }
         return o;
     }
-    function clean(x) {
-        var o = {};
-        for (var i in x) { if (x[i]) { o[i] = x[i]; } }
-        return o;
-    }
     // get the content of a text node, if any
     function nodeVal(x) {
         if (x) { norm(x); }
         return (x && x.textContent) || '';
+    }
+    // get the contents of multiple text nodes, if present
+    function getMulti(x, ys) {
+        var o = {}, n, k;
+        for (k = 0; k < ys.length; k++) {
+            n = get1(x, ys[k]);
+            if (n) o[ys[k]] = nodeVal(n);
+        }
+        return o;
     }
     // get one coordinate from a coordinate array, if any
     function coord1(v) { return numarray(v.replace(removeSpace, '').split(',')); }
@@ -380,14 +384,16 @@ var toGeoJSON = (function() {
                 };
             }
             function getProperties(node) {
-                var meta = ['name', 'cmt', 'desc', 'author', 'copyright',
-                            'link', 'time', 'keywords'],
-                    prop = {},
-                    k;
-                for (k = 0; k < meta.length; k++) {
-                    prop[meta[k]] = nodeVal(get1(node, meta[k]));
+                var prop, links;
+                prop = getMulti(node, ['name', 'cmt', 'desc', 'time', 'keywords']);
+                links = get(node, 'link');
+                if (links.length) prop.links = [];
+                for (var i = 0, link; i < links.length; i++) {
+                    link = getMulti(links[i], ['text', 'type']);
+                    link.href = attr(links[i], 'href');
+                    prop.links.push(link);
                 }
-                return clean(prop);
+                return prop;
             }
             return gj;
         }


### PR DESCRIPTION
Some properties are compound nodes where information is stored in attributes
and child nodes. We do not support these properties.
This commit removes the suggestion that we support them and adds support for
link property tags.

Previous link handling behavior was inconsistent, as noted in #23. This commit breaks backward compatibility to whatever inconsistent behavior could have been relied upon.