### PR TITLE
Support GPX waypoint type tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ just AJAX.
 
 * [x] Line Paths
 * [ ] Properties
-  * [x] 'name', 'cmt', 'desc', 'link', 'time', 'keywords' tags
+  * [x] 'name', 'cmt', 'desc', 'link', 'time', 'keywords', 'sym', 'type' tags
   * [ ] 'author', 'copyright' tags
 
 ## FAQ

--- a/test/data/blue_hills.gpx.geojson
+++ b/test/data/blue_hills.gpx.geojson
@@ -7559,7 +7559,8 @@
                 "name": "LOOKOUT",
                 "desc": "Lookout Rock",
                 "time": "2001-06-24T20:59:47Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "rock"
             },
             "geometry": {
                 "type": "Point",
@@ -7576,7 +7577,8 @@
                 "name": "1072",
                 "desc": "1072",
                 "time": "2001-10-13T23:50:58Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7593,7 +7595,8 @@
                 "name": "1081",
                 "desc": "1081",
                 "time": "2001-06-24T20:59:47Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7610,7 +7613,8 @@
                 "name": "1082",
                 "desc": "1082",
                 "time": "2001-05-26T21:52:38Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7657,7 +7661,8 @@
                 "name": "1103",
                 "desc": "1103",
                 "time": "2001-05-26T21:52:38Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7674,7 +7679,8 @@
                 "name": "1110",
                 "desc": "1110",
                 "time": "2001-06-24T20:59:48Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7691,7 +7697,8 @@
                 "name": "1114",
                 "desc": "1114",
                 "time": "2001-05-26T21:52:38Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7708,7 +7715,8 @@
                 "name": "1135",
                 "desc": "1135",
                 "time": "2001-10-13T23:50:58Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7725,7 +7733,8 @@
                 "name": "1140 LOGS",
                 "desc": "1140 - The log pyramid",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Danger Area"
+                "sym": "Danger Area",
+                "type": "Danger Area"
             },
             "geometry": {
                 "type": "Point",
@@ -7742,7 +7751,8 @@
                 "name": "1141",
                 "desc": "1141",
                 "time": "2001-06-24T20:59:47Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7759,7 +7769,8 @@
                 "name": "1175",
                 "desc": "1175",
                 "time": "2001-05-26T21:52:38Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7791,7 +7802,8 @@
                 "name": "1185",
                 "desc": "1185",
                 "time": "2001-06-24T20:59:47Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7823,7 +7835,8 @@
                 "name": "2070",
                 "desc": "2070",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7840,7 +7853,8 @@
                 "name": "2096",
                 "desc": "2096",
                 "time": "2001-06-24T20:59:46Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7857,7 +7871,8 @@
                 "name": "2112",
                 "desc": "2112",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7874,7 +7889,8 @@
                 "name": "7672 ROAD",
                 "desc": "Road",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Truck Stop"
+                "sym": "Truck Stop",
+                "type": "Truck Stop"
             },
             "geometry": {
                 "type": "Point",
@@ -7891,7 +7907,8 @@
                 "name": "7711 ROAD",
                 "desc": "Unquity Road",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Truck Stop"
+                "sym": "Truck Stop",
+                "type": "Truck Stop"
             },
             "geometry": {
                 "type": "Point",
@@ -7908,7 +7925,8 @@
                 "name": "BEACH",
                 "desc": "Beach",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7925,7 +7943,8 @@
                 "name": "BEECH-RUN",
                 "desc": "BEECH-RUN",
                 "time": "2001-05-26T21:52:41Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -7941,7 +7960,8 @@
                 "name": "BOYCE",
                 "desc": "Boyce Hill",
                 "time": "2001-05-26T21:52:44Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -7958,7 +7978,8 @@
                 "name": "BREAKNECK",
                 "desc": "Breakneck Ledge",
                 "time": "2001-05-26T21:52:45Z",
-                "sym": "Dangerous Area"
+                "sym": "Dangerous Area",
+                "type": "Dangerous Area"
             },
             "geometry": {
                 "type": "Point",
@@ -7975,7 +7996,8 @@
                 "name": "BREEZEHILL",
                 "desc": "BREEZEHILL",
                 "time": "2001-05-26T21:52:45Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -7992,7 +8014,8 @@
                 "name": "BUCK",
                 "desc": "Buck Hill",
                 "time": "2001-05-26T21:52:46Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8009,7 +8032,8 @@
                 "name": "BURNT-HILL",
                 "desc": "BURNT-HILL",
                 "time": "2001-05-26T21:52:46Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8026,7 +8050,8 @@
                 "name": "BWZFLATO",
                 "desc": "BWZFLATO",
                 "time": "2001-10-13T23:50:58Z",
-                "sym": "Shipwreck"
+                "sym": "Shipwreck",
+                "type": "Shipwreck"
             },
             "geometry": {
                 "type": "Point",
@@ -8043,7 +8068,8 @@
                 "name": "DEADEND",
                 "desc": "Dead End",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Zoo"
+                "sym": "Zoo",
+                "type": "Zoo"
             },
             "geometry": {
                 "type": "Point",
@@ -8060,7 +8086,8 @@
                 "name": "DEL-FLAT01",
                 "desc": "DEL-FLAT01",
                 "time": "2001-05-26T21:52:52Z",
-                "sym": "Shipwreck"
+                "sym": "Shipwreck",
+                "type": "Shipwreck"
             },
             "geometry": {
                 "type": "Point",
@@ -8077,7 +8104,8 @@
                 "name": "DEW-FLAT01",
                 "desc": "DEW-FLAT01",
                 "time": "2001-05-26T21:52:53Z",
-                "sym": "Shipwreck"
+                "sym": "Shipwreck",
+                "type": "Shipwreck"
             },
             "geometry": {
                 "type": "Point",
@@ -8094,7 +8122,8 @@
                 "name": "HANCOCK",
                 "desc": "Hancock Hill",
                 "time": "2001-05-26T21:53:00Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8111,7 +8140,8 @@
                 "name": "HEMINGWAY",
                 "desc": "Hemingway Hill",
                 "time": "2001-05-26T21:53:01Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8128,7 +8158,8 @@
                 "name": "HOUGHTON",
                 "desc": "Houghton Hill",
                 "time": "2001-05-26T21:53:03Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8145,7 +8176,8 @@
                 "name": "HOUGHTPOND",
                 "desc": "HOUGHTPOND",
                 "time": "2001-05-26T21:53:03Z",
-                "sym": "Fishing Area"
+                "sym": "Fishing Area",
+                "type": "Fishing Area"
             },
             "geometry": {
                 "type": "Point",
@@ -8162,7 +8194,8 @@
                 "name": "HQ",
                 "desc": "Headquarters",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Building"
+                "sym": "Building",
+                "type": "Building"
             },
             "geometry": {
                 "type": "Point",
@@ -8179,7 +8212,8 @@
                 "name": "LITTLBLUHI",
                 "desc": "LITTLBLUHI",
                 "time": "2001-05-26T21:53:08Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",
@@ -8196,7 +8230,8 @@
                 "name": "LOOKOUT",
                 "desc": "Lookout Rock",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Scenic Area"
+                "sym": "Scenic Area",
+                "type": "Scenic Area"
             },
             "geometry": {
                 "type": "Point",
@@ -8213,7 +8248,8 @@
                 "name": "PARKING",
                 "desc": "Parking",
                 "time": "2001-05-26T21:52:36Z",
-                "sym": "Car"
+                "sym": "Car",
+                "type": "Car"
             },
             "geometry": {
                 "type": "Point",
@@ -8230,7 +8266,8 @@
                 "name": "PIT",
                 "desc": "Gravel Pit",
                 "time": "2001-10-13T23:50:58Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -8247,7 +8284,8 @@
                 "name": "SINGLE",
                 "desc": "Pond Singletrack",
                 "time": "2001-06-24T20:59:46Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -8264,7 +8302,8 @@
                 "name": "SKIAREA",
                 "desc": "Ski Area",
                 "time": "2001-06-24T20:59:46Z",
-                "sym": "Dot"
+                "sym": "Dot",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -8281,7 +8320,8 @@
                 "name": "SUMMIT",
                 "desc": "Summit",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Tall Tower"
+                "sym": "Tall Tower",
+                "type": "Dot"
             },
             "geometry": {
                 "type": "Point",
@@ -8298,7 +8338,8 @@
                 "name": "SUMMITROAD",
                 "desc": "Summit Road",
                 "time": "2001-05-26T21:52:37Z",
-                "sym": "Truck Stop"
+                "sym": "Truck Stop",
+                "type": "Truck Stop"
             },
             "geometry": {
                 "type": "Point",
@@ -8315,7 +8356,8 @@
                 "name": "TUCKER",
                 "desc": "Tucker Hill",
                 "time": "2001-05-26T21:53:33Z",
-                "sym": "Summit"
+                "sym": "Summit",
+                "type": "Summit"
             },
             "geometry": {
                 "type": "Point",

--- a/test/data/gdal.gpx.geojson
+++ b/test/data/gdal.gpx.geojson
@@ -72,22 +72,22 @@
                 "time": "2007-11-25T17:58:00+01:00",
                 "links": [
                     {
+                        "href": "href",
                         "text": "text",
-                        "type": "type",
-                        "href": "href"
+                        "type": "type"
                     },
                     {
+                        "href": "href2",
                         "text": "text2",
-                        "type": "type2",
-                        "href": "href2"
+                        "type": "type2"
                     },
                     {
+                        "href": "href3",
                         "text": "text3",
-                        "type": "type3",
-                        "href": "href3"
+                        "type": "type3"
                     }
                 ],
-                "sym": ""
+                "type": "type"
             },
             "geometry": {
                 "type": "Point",
@@ -100,9 +100,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [

--- a/test/data/wpt.gpx.geojson
+++ b/test/data/wpt.gpx.geojson
@@ -3,9 +3,7 @@
     "features": [
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -16,9 +14,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -29,9 +25,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -42,9 +36,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -55,9 +47,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -68,9 +58,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -81,9 +69,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -94,9 +80,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -107,9 +91,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -120,9 +102,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -133,9 +113,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -146,9 +124,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -159,9 +135,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -172,9 +146,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -185,9 +157,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -198,9 +168,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -211,9 +179,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -224,9 +190,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -237,9 +201,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -250,9 +212,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -263,9 +223,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -276,9 +234,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -289,9 +245,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -302,9 +256,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -315,9 +267,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -328,9 +278,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -341,9 +289,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -354,9 +300,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -367,9 +311,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -380,9 +322,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -393,9 +333,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -406,9 +344,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -419,9 +355,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -432,9 +366,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -445,9 +377,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -458,9 +388,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -471,9 +399,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -484,9 +410,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -497,9 +421,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -510,9 +432,7 @@
         },
         {
             "type": "Feature",
-            "properties": {
-                "sym": ""
-            },
+            "properties": {},
             "geometry": {
                 "type": "Point",
                 "coordinates": [

--- a/togeojson.js
+++ b/togeojson.js
@@ -38,6 +38,8 @@ var toGeoJSON = (function() {
         }
         return o;
     }
+    // add properties of Y to X, overwriting if present in both
+    function extend(x, y) { for (var k in y) x[k] = y[k]; }
     // get one coordinate from a coordinate array, if any
     function coord1(v) { return numarray(v.replace(removeSpace, '').split(',')); }
     // get all coordinates from a coordinate array as [[],[]]
@@ -373,7 +375,7 @@ var toGeoJSON = (function() {
             }
             function getPoint(node) {
                 var prop = getProperties(node);
-                prop.sym = nodeVal(get1(node, 'sym'));
+                extend(prop, getMulti(node, ['sym', 'type']));
                 return {
                     type: 'Feature',
                     properties: prop,
@@ -389,8 +391,8 @@ var toGeoJSON = (function() {
                 links = get(node, 'link');
                 if (links.length) prop.links = [];
                 for (var i = 0, link; i < links.length; i++) {
-                    link = getMulti(links[i], ['text', 'type']);
-                    link.href = attr(links[i], 'href');
+                    link = { href: attr(links[i], 'href') };
+                    extend(link, getMulti(links[i], ['text', 'type']));
                     prop.links.push(link);
                 }
                 return prop;


### PR DESCRIPTION
This also introduces an extend feature that should only be used with simple
objects (non-inherited property-value pairs). Also, sym properties are no
longer generated when they are absent from the GPX file.