### PR TITLE
linkrot corrrection

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                     <textarea id='output'></textarea></div>
             </div>
             <div class='pad2 center'>
-                <a class='button' href='https://raw.github.com/tmcw/togeojson/gh-pages/togeojson.js' download='togeojson.js'>⬇ togeojson.js <small>less than 10 kB minified</small></a>
+                <a class='button' href='https://raw.githubusercontent.com/mapbox/togeojson/master/togeojson.js' download='togeojson.js'>⬇ togeojson.js <small>less than 10 kB minified</small></a>
                 <br /><br />
                 <small>
                     <a href='http://github.com/tmcw/togeojson'>or clone &amp; contribute on github</a>


### PR DESCRIPTION
Original URL throws 404, swapped out for current URL.
See a few more links to original creator's repository...was going to swap them out, but not really sure if that is desired or not.