### PR TITLE
reflect color in Placemark properties

### DIFF
--- a/togeojson.js
+++ b/togeojson.js
@@ -248,6 +248,10 @@ var toGeoJSON = (function() {
                                 if (href) properties.icon = href;
                             }
                         }
+                        var color = get1(iconStyle, 'color');
+                        if(color){
+                            properties.color = nodeVal(color);
+                        }
                     }
                 }
                 if (description) properties.description = description;


### PR DESCRIPTION
Per Googles KML Reference, https://developers.google.com/kml/documentation/kmlreference#iconstyle
Icon Style can have a color.

Per Google Maps / MyMaps Editor / Export to KML https://www.google.com/mymaps
Inspection of the KML written by their tool, they also set the color property for Placemark.