### PR TITLE
reflect color in Placemark properties

### DIFF
--- a/togeojson.js
+++ b/togeojson.js
@@ -247,6 +247,10 @@ var toGeoJSON = (function() {
                                 var href = nodeVal(get1(icon, 'href'));
                                 if (href) properties.icon = href;
                             }
+                            var placemarkColor = get1(iconStyle, 'color');
+                            if(placemarkColor){
+                                properties.color = nodeVal(placemarkColor);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Per Googles KML Reference, https://developers.google.com/kml/documentation/kmlreference#iconstyle
Icon Style can have a color.

Per Google Maps / MyMaps Editor / Export to KML https://www.google.com/mymaps
Inspection of the KML written by their tool, they also set the color property for Placemark.