### PR TITLE
Preserve GPX metadata and trkpt extensions in converted geojson

### DIFF
--- a/test/data/trkpt-extensions.gpx
+++ b/test/data/trkpt-extensions.gpx
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx creator="WTracks"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+    xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0"
+    xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
+<metadata>
+  <name>GPX extension tests</name>
+  <desc></desc>
+  <author><name>WTracks</name></author>
+  <link href='https://opoto.github.io/wtracks/'>
+    <text>WTracks</text>
+    <type>text/html</type>
+  </link>
+  <time>2019-12-04T23:42:08.027Z</time>
+  <bounds minlat="43.24570289202524" minlon="5.346221923828126" maxlat="43.26670632323062" maxlon="5.406861305236817"/>
+</metadata>
+<wpt lat="43.25667824482849" lon="5.376101510881589"><name>dummy</name><desc>wpt extensions are discarded</desc><ele>-1</ele>
+  <extensions><gpxdata:hr>20</gpxdata:hr></extensions>
+</wpt>
+<trk><name>track 1</name>
+  <trkseg>
+    <trkpt lat="43.256239" lon="5.375854"><ele>52</ele><time>2019-11-16T11:28:40Z</time>
+      <extensions><gpxdata:hr>80</gpxdata:hr><gpxdata:cadence>53</gpxdata:cadence><power>1</power></extensions>
+    </trkpt>
+    <trkpt lat="43.256159" lon="5.375783"><ele>52</ele><time>2019-11-16T11:28:44Z</time>
+      <extensions><gpxdata:hr>81</gpxdata:hr><gpxdata:cadence>91</gpxdata:cadence><power>2</power></extensions>
+    </trkpt>
+    <trkpt lat="43.256078" lon="5.37567"><ele>52</ele><time>2019-11-16T11:28:49Z</time>
+      <extensions><gpxdata:hr>82</gpxdata:hr><gpxdata:cadence>91</gpxdata:cadence></extensions>
+    </trkpt>
+  </trkseg>
+  <trkseg>
+    <trkpt lat="43.256253" lon="5.375862"><ele>0.6</ele><time>2019-11-16T11:28:40Z</time>
+      <extensions><gpxtpx:TrackPointExtension><gpxtpx:cad>53</gpxtpx:cad></gpxtpx:TrackPointExtension><power>4</power></extensions>
+    </trkpt>
+    <trkpt lat="43.256213" lon="5.375858"><ele>0.6</ele><time>2019-11-16T11:28:42Z</time>
+      <extensions><gpxtpx:TrackPointExtension><gpxtpx:cad>61</gpxtpx:cad></gpxtpx:TrackPointExtension><power>5</power></extensions>
+    </trkpt>
+    <trkpt lat="43.256179" lon="5.375822"><ele>0.6</ele><time>2019-11-16T11:28:43Z</time>
+      <extensions><gpxtpx:TrackPointExtension><gpxtpx:cad>89</gpxtpx:cad></gpxtpx:TrackPointExtension></extensions>
+    </trkpt>
+    <trkpt lat="43.256157" lon="5.375797"><ele>0.6</ele><time>2019-11-16T11:28:44Z</time>
+      <extensions><gpxtpx:TrackPointExtension><gpxtpx:cad>91</gpxtpx:cad></gpxtpx:TrackPointExtension></extensions>
+    </trkpt>
+  </trkseg>
+</trk></gpx>

--- a/togeojson.js
+++ b/togeojson.js
@@ -315,9 +315,14 @@ var toGeoJSON = (function() {
                 tracks = get(doc, 'trk'),
                 routes = get(doc, 'rte'),
                 waypoints = get(doc, 'wpt'),
+                metadata = get(doc, 'metadata'),
                 // a feature collection
                 gj = fc(),
                 feature;
+            // keep metadata
+            if (metadata && metadata[0]) {
+              gj.metadata = getMetadata(metadata[0]);
+            }
             for (i = 0; i < tracks.length; i++) {
                 feature = getTrack(tracks[i]);
                 if (feature) gj.features.push(feature);
@@ -328,6 +333,16 @@ var toGeoJSON = (function() {
             }
             for (i = 0; i < waypoints.length; i++) {
                 gj.features.push(getPoint(waypoints[i]));
+            }
+            // returns GPX metadata
+            function getMetadata(metadata) {
+              var md = {};
+              var item = metadata.firstElementChild;
+              while (item) {
+                md[item.tagName] = item.textContent.trim();
+                item = item.nextElementSibling;
+              }
+              return md;
             }
             function initializeArray(arr, size) {
                 for (var h = 0; h < size; h++) {


### PR DESCRIPTION
In addition to the heart rate extension that is already converted, this commits stores metadata and all GPX trkpt extensions into the generated geojson, so that this data is not lost and can be processed by the application. The corresponding xmlns are also stored.